### PR TITLE
Support for C++11 and (with a workaround for now) C++14

### DIFF
--- a/netbeans_configurations.lua
+++ b/netbeans_configurations.lua
@@ -137,6 +137,19 @@
 		if not config.isDebugBuild(cfg) and cfg.flags.ReleaseRuntime then
 			_p(5, '<developmentMode>5</developmentMode>')
 		end
+		
+		-- C++11/14 support
+		if toolName == 'ccTool' then
+			if cfg.flags['C++14'] then
+				-- todo: Change to correct Number once NetBeans supports it.
+				-- For now C++11 support + gcc flag
+				_p(5, '<standard>8</standard>')
+				table.insert(flags, "-std=c++14")
+			elseif cfg.flags['C++11'] then
+				_p(5, '<standard>8</standard>')
+			end
+		end
+
 		_p(5, '<incDir>')
 		for _, incdir in ipairs(cfg.includedirs) do
 			_p(6, '<pElem>%s</pElem>', m.escapepath(cfg.project, incdir))


### PR DESCRIPTION
As the title says.
NB has no native support for 14 yet, so I'm telling it to use C++11 and to add the appropriate gcc flag
